### PR TITLE
Beta UniFi Network Application 6.4.51

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.4.50-00f579cd4c/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.4.51-56f5e9d9a5/UniFi.unix.zip"
 
 
 # The rc script associated with this branch or fork:


### PR DESCRIPTION
Beta UniFi Network Application 6.4.51

Install command: fetch -o - https://git.io/JEEbc | sh -s
(install at your own risk, back up your DB first)