### PR TITLE
Official UniFi Network Application 6.5.52

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.5.51-2767b412a8/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.5.52-4b1a918bba/UniFi.unix.zip"
 
 
 # The rc script associated with this branch or fork:


### PR DESCRIPTION
Official UniFi Network Application 6.5.51
[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-6-5-52/b7ca4128-c6f7-4741-9da1-e216db190452)

Install command: fetch -o - https://git.io/J13Rm | sh -s

install at your own risk, back up your DB first