### PR TITLE
beta-UniFi-Network-Application-6.5.53 MongoDB4.0

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -168,7 +168,7 @@ AddPkg snappy
 AddPkg cyrus-sasl
 AddPkg icu
 AddPkg boost-libs
-AddPkg mongodb42
+AddPkg mongodb40
 AddPkg unzip
 AddPkg pcre
 


### PR DESCRIPTION
Official-UniFi-Network-Application-6.5.53
modified to mongodb 4.0

Install command: fetch -o - https://git.io/J1NuT | sh -s

install at your own risk, back up your DB first