### PR TITLE
Official UniFi Network Application 6.5.54

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.5.53/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.5.54-3b5d40203c/UniFi.unix.zip"
 
 
 # The rc script associated with this branch or fork:
@@ -168,7 +168,7 @@ AddPkg snappy
 AddPkg cyrus-sasl
 AddPkg icu
 AddPkg boost-libs
-AddPkg mongodb40
+AddPkg mongodb42
 AddPkg unzip
 AddPkg pcre
 

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -168,7 +168,7 @@ AddPkg snappy
 AddPkg cyrus-sasl
 AddPkg icu
 AddPkg boost-libs
-AddPkg mongodb42
+AddPkg mongodb40
 AddPkg unzip
 AddPkg pcre
 


### PR DESCRIPTION
Official UniFi Network Application 6.5.54
[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-6-5-54/d717f241-48bb-4979-8b10-99db36ddabe1)

MongoDB 4.2
Install command: fetch -o - https://git.io/JDOh2 | sh -s

MongoDB 4.0
Install command: fetch -o - https://git.io/JD3aA | sh -s

install at your own risk, back up your DB first

NOTE: 2 Option for the install link has been added 1 for 4.2 and the other 4.0, for those having issues with instability or data/DB corruption please follow the guide on resolving/upgrading MongoDB or use the 4.0 install link.
