### PR TITLE
Official UniFiNetworkApplication 6.5.55 MongoDB40

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.5.54-3b5d40203c/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.5.55-1d0581c00d//UniFi.unix.zip"
 
 
 # The rc script associated with this branch or fork:


### PR DESCRIPTION
Official UniFi Network Application 6.5.55
[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e)

fix for log4j

MongoDB 4.0
Install command: fetch -o - https://git.io/JD2KW | sh -s

install at your own risk, back up your DB first

NOTE: for those having corrupts DB after installing  6.5.55 MongoDB42 