### PR TITLE
Official UniFiNetworkApplication 6.5.55 MongoDB42

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -168,7 +168,7 @@ AddPkg snappy
 AddPkg cyrus-sasl
 AddPkg icu
 AddPkg boost-libs
-AddPkg mongodb40
+AddPkg mongodb42
 AddPkg unzip
 AddPkg pcre
 


### PR DESCRIPTION
Official UniFi Network Application 6.5.55
[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e)

fix for log4j

MongoDB 4.2
Install command: fetch -o - https://git.io/JD2Pe | sh -s

install at your own risk, back up your DB first