### PR TITLE
Beta UniFiNetworkApplication 7.0.18 MongoDB40

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.0.15-aa76488648/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.0.18-e55ea27371/UniFi.unix.zip"
 
 
 # The rc script associated with this branch or fork:


### PR DESCRIPTION
Beta UniFiNetworkApplication 7.0.18 MongoDB40
[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-7-0-18/a620f1da-264c-49ae-8fe6-eddf67dee179)

MongoDB 4.0
Install command: fetch -o - https://tinyurl.com/2p8pp8ba | sh -s

install at your own risk, back up your DB first

NOTE: for those having corrupts DB after installing version with MongoDB42