### PR TITLE
UniFiNetworkApplication 7.1.66 with different pkg site

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -29,13 +29,11 @@ fi
 ABI=`/usr/sbin/pkg config abi`
 
 # FreeBSD package source:
-#FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/${ABI}/latest/All/"
-#FREEBSD_PACKAGE_URL="http://pkg0.kul.freebsd.org/${ABI}/latest/All/"
-FREEBSD_PACKAGE_URL="https://mirrors.xtom.nl/freebsd-pkg/${ABI}/latest/All/"
+FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/${ABI}/latest/All/"
 
 # FreeBSD package list:
-#FREEBSD_PACKAGE_LIST_URL="https://pkg.freebsd.org/${ABI}/latest/packagesite.txz"
-FREEBSD_PACKAGE_LIST_URL="https://mirrors.xtom.nl/freebsd-pkg/${ABI}/latest/packagesite.txz"
+FREEBSD_PACKAGE_LIST_URL="https://pkg.freebsd.org/${ABI}/latest/packagesite.txz"
+
 
 # Stop the controller if it's already running...
 # First let's try the rc script if it exists:
@@ -135,7 +133,7 @@ AddPkg freetype2
 AddPkg fontconfig
 AddPkg alsa-lib
 AddPkg mpdecimal
-AddPkg python37
+#AddPkg python37
 AddPkg libfontenc
 AddPkg mkfontscale
 AddPkg dejavu
@@ -157,8 +155,8 @@ AddPkg libXrender
 AddPkg libinotify
 AddPkg javavmwrapper
 AddPkg java-zoneinfo
-AddPkg openjdk8
-AddPkg snappyjava
+#AddPkg openjdk8
+#AddPkg snappyjava
 AddPkg snappy
 AddPkg cyrus-sasl
 AddPkg icu

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -31,11 +31,11 @@ ABI=`/usr/sbin/pkg config abi`
 # FreeBSD package source:
 #FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/${ABI}/latest/All/"
 #FREEBSD_PACKAGE_URL="http://pkg0.kul.freebsd.org/${ABI}/latest/All/"
-FREEBSD_PACKAGE_URL="https://mirrors.xtom.nl/freebsd-pkg/${ABI}/quarterly/All/"
+FREEBSD_PACKAGE_URL="https://mirrors.xtom.nl/freebsd-pkg/${ABI}/latest/All/"
 
 # FreeBSD package list:
 #FREEBSD_PACKAGE_LIST_URL="https://pkg.freebsd.org/${ABI}/latest/packagesite.txz"
-FREEBSD_PACKAGE_LIST_URL="https://mirrors.xtom.nl/freebsd-pkg/${ABI}/quarterly/packagesite.txz"
+FREEBSD_PACKAGE_LIST_URL="https://mirrors.xtom.nl/freebsd-pkg/${ABI}/latest/packagesite.txz"
 
 # Stop the controller if it's already running...
 # First let's try the rc script if it exists:

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -30,12 +30,12 @@ ABI=`/usr/sbin/pkg config abi`
 
 # FreeBSD package source:
 #FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/${ABI}/latest/All/"
-FREEBSD_PACKAGE_URL="http://pkg0.kul.freebsd.org/${ABI}/latest/All/"
-#https://mirrors.xtom.nl/freebsd-pkg/FreeBSD%3A12%3Aamd64/quarterly/All/ ?
+#FREEBSD_PACKAGE_URL="http://pkg0.kul.freebsd.org/${ABI}/latest/All/"
+FREEBSD_PACKAGE_URL="https://mirrors.xtom.nl/freebsd-pkg/${ABI}/latest/All/"
 
 # FreeBSD package list:
 #FREEBSD_PACKAGE_LIST_URL="https://pkg.freebsd.org/${ABI}/latest/packagesite.txz"
-FREEBSD_PACKAGE_LIST_URL="http://pkg0.kul.freebsd.org/${ABI}/latest/packagesite.txz"
+FREEBSD_PACKAGE_LIST_URL="https://mirrors.xtom.nl/freebsd-pkg/${ABI}/latest/packagesite.txz"
 
 # Stop the controller if it's already running...
 # First let's try the rc script if it exists:

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -31,11 +31,11 @@ ABI=`/usr/sbin/pkg config abi`
 # FreeBSD package source:
 #FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/${ABI}/latest/All/"
 #FREEBSD_PACKAGE_URL="http://pkg0.kul.freebsd.org/${ABI}/latest/All/"
-FREEBSD_PACKAGE_URL="https://mirrors.xtom.nl/freebsd-pkg/${ABI}/latest/All/"
+FREEBSD_PACKAGE_URL="https://mirrors.xtom.nl/freebsd-pkg/${ABI}/quarterly/All/"
 
 # FreeBSD package list:
 #FREEBSD_PACKAGE_LIST_URL="https://pkg.freebsd.org/${ABI}/latest/packagesite.txz"
-FREEBSD_PACKAGE_LIST_URL="https://mirrors.xtom.nl/freebsd-pkg/${ABI}/latest/packagesite.txz"
+FREEBSD_PACKAGE_LIST_URL="https://mirrors.xtom.nl/freebsd-pkg/${ABI}/quarterly/packagesite.txz"
 
 # Stop the controller if it's already running...
 # First let's try the rc script if it exists:

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -29,10 +29,12 @@ fi
 ABI=`/usr/sbin/pkg config abi`
 
 # FreeBSD package source:
-FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/${ABI}/latest/All/"
+#FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/${ABI}/latest/All/"
+FREEBSD_PACKAGE_URL="https://pkg0.kul.freebsd.org/${ABI}/latest/All/"
 
 # FreeBSD package list:
-FREEBSD_PACKAGE_LIST_URL="https://pkg.freebsd.org/${ABI}/latest/packagesite.txz"
+#FREEBSD_PACKAGE_LIST_URL="https://pkg.freebsd.org/${ABI}/latest/packagesite.txz"
+FREEBSD_PACKAGE_LIST_URL="https://pkg0.kul.freebsd.org/${ABI}/latest/packagesite.txz"
 
 # Stop the controller if it's already running...
 # First let's try the rc script if it exists:

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -30,11 +30,12 @@ ABI=`/usr/sbin/pkg config abi`
 
 # FreeBSD package source:
 #FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/${ABI}/latest/All/"
-FREEBSD_PACKAGE_URL="https://pkg0.kul.freebsd.org/${ABI}/latest/All/"
+FREEBSD_PACKAGE_URL="http://pkg0.kul.freebsd.org/${ABI}/latest/All/"
+#https://mirrors.xtom.nl/freebsd-pkg/FreeBSD%3A12%3Aamd64/quarterly/All/ ?
 
 # FreeBSD package list:
 #FREEBSD_PACKAGE_LIST_URL="https://pkg.freebsd.org/${ABI}/latest/packagesite.txz"
-FREEBSD_PACKAGE_LIST_URL="https://pkg0.kul.freebsd.org/${ABI}/latest/packagesite.txz"
+FREEBSD_PACKAGE_LIST_URL="http://pkg0.kul.freebsd.org/${ABI}/latest/packagesite.txz"
 
 # Stop the controller if it's already running...
 # First let's try the rc script if it exists:

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.1.66-c70daa41cf/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.2.85-92448da610/UniFi.unix.zip"
 
 
 # The rc script associated with this branch or fork:
@@ -116,7 +116,7 @@ AddPkg () {
  	if [ `pkg info | grep -c $pkgname-$pkgvers` -eq 1 ]; then
 	     echo "Package $pkgname-$pkgvers already installed."
 	else
-	     env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg add -f ${FREEBSD_PACKAGE_URL}${pkgname}-${pkgvers}.txz
+	     env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg add -f ${FREEBSD_PACKAGE_URL}${pkgname}-${pkgvers}.pkg
 
 	     # if update openjdk8 then force detele snappyjava to reinstall for new version of openjdk
 	     if [ "$pkgname" == "openjdk8" ]; then
@@ -133,7 +133,7 @@ AddPkg freetype2
 AddPkg fontconfig
 AddPkg alsa-lib
 AddPkg mpdecimal
-#AddPkg python37
+AddPkg python37
 AddPkg libfontenc
 AddPkg mkfontscale
 AddPkg dejavu
@@ -155,8 +155,8 @@ AddPkg libXrender
 AddPkg libinotify
 AddPkg javavmwrapper
 AddPkg java-zoneinfo
-#AddPkg openjdk8
-#AddPkg snappyjava
+AddPkg openjdk8
+AddPkg snappyjava
 AddPkg snappy
 AddPkg cyrus-sasl
 AddPkg icu


### PR DESCRIPTION
This is a test branch with a different Package Site
Replace pkg/repo https://pkg.freebsd.org/ to https://mirrors.xtom.nl/freebsd-pkg/
since original link has issue with java apps being not found
see thread #287 

*using original repository server
*all package enabled
*change code to use .pkg instead of . txz
*${FREEBSD_PACKAGE_URL}${pkgname}-${pkgvers}**.pkg**
Install command: fetch -o - https://tinyurl.com/2j9n72y3 | sh -s


RC UniFiNetworkApplication 7.1.66
**latest-using original repository server**
Install command: fetch -o - https://tinyurl.com/32adap2h | sh -s
**NOTE: commented out python37, openjdk8 and snappyjava**

quarterly
Install command: fetch -o - https://tinyurl.com/2skkp9k5 | sh -s

latest
Install command: fetch -o - https://tinyurl.com/em46zp99 | sh -s
