### PR TITLE
Official UniFi Network Application 7.2.97

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -129,6 +129,7 @@ AddPkg () {
 
 #Add the following Packages for installation or reinstallation (if something was removed)
 AddPkg png
+AddPkg brotli
 AddPkg freetype2
 AddPkg fontconfig
 AddPkg alsa-lib

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.2.92/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.2.97/UniFi.unix.zip"
 
 
 # The rc script associated with this branch or fork:


### PR DESCRIPTION
Official UniFi Network Application 7.2.97
[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-7-2-97/d2f71152-3001-42cd-834c-9245d86f4e72)
Install command: fetch -o - https://tinyurl.com/2p9fccf7 | sh -s

EDIT:
added brotli package

Bugfixes
Fix invalid interface configuration in rare cases.
Fix MAC Cloning with identical MAC addresses could cause port misconfigurations.

To be merge with base in a months time if no issues arise

NOTE: This is using the original code from the base, for newer or beta firmware use #292
[Beta UniFi Network Application 7.4.140 #292](https://github.com/unofficial-unifi/unifi-pfsense/pull/292)