### PR TITLE
Only run pkg commands if there are discontinued packages to uninstall

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -86,8 +86,7 @@ echo " done."
 
 
 echo "Removing discontinued packages..."
-old_mongos=`pkg info | grep mongodb | grep -v ${CURRENT_MONGODB_VERSION}`
-for old_mongo in "${old_mongos}"; do
+pkg info | grep mongodb | grep -v ${CURRENT_MONGODB_VERSION} | while read -r old_mongo; do
   package=`echo "$old_mongo" | cut -d' ' -f1`
   pkg unlock -yq ${package}
   env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg delete ${package}


### PR DESCRIPTION
Currently, if there are no outdated/discontinued MongoDB packages installed, we get this output:
```
Usage: pkg lock [-lqy] [-a|[-Cgix] ]
       pkg lock --has-locked-packages
       pkg unlock [-lqy] [-a|[-Cgix] ]
For more information see 'pkg help lock'.
Usage: pkg delete [-DfnqRy] [-Cgix] ...
       pkg delete [-Dnqy] -a
```

This is due to the loop still running even if the `$old_mongos` variable is empty. My changes make it so the pkg unlock/delete commands only run if there are packages to delete.