### PR TITLE
Update install-unifi.sh

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -141,7 +141,6 @@ AddPkg dejavu
 AddPkg giflib
 AddPkg xorgproto
 AddPkg libXdmcp
-AddPkg libpthread-stubs
 AddPkg libXau
 AddPkg libxcb
 AddPkg libICE


### PR DESCRIPTION
removed libpthread-stubs
for 7.2.97 script

UniFi Network Application 7.2.97
Install command: fetch -o - https://tinyurl.com/4wvn5p23 | sh -s
