### PR TITLE
Beta Unifi 7.4.156 Test Fix PFsense 2.6 

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -160,7 +160,6 @@ AddPkg dejavu
 AddPkg giflib
 AddPkg xorgproto
 AddPkg libXdmcp
-AddPkg libpthread-stubs
 AddPkg libXau
 AddPkg libxcb
 AddPkg libICE

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.4.154-14038469fd/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.4.156-6ee9e412d1/UniFi.unix.zip"
 
 
 # The rc script associated with this branch or fork:
@@ -149,6 +149,11 @@ AddPkg () {
 #Add the following Packages for installation or reinstallation (if something was removed)
 AddPkg png
 AddPkg brotli
+AddPkg jpeg-turbo
+AddPkg zstd
+AddPkg libdeflate
+AddPkg jbigkit
+AddPkg tiff
 AddPkg freetype2
 AddPkg fontconfig
 AddPkg alsa-lib


### PR DESCRIPTION
Beta Unifi 7.4.156
removed - AddPkg libpthread-stubs
added - AddPkg jpeg-turbo
added - AddPkg zstd
added - AddPkg libdeflate
added - AddPkg jbigkit
added - AddPkg tiff

Test fix if installer script would push and Unifi would function correctly

beta UniFi Network Application 7.4.156
Install command: fetch -o - https://tinyurl.com/bdzx6ks7 | sh -s