### PR TITLE
Fix Install Script with latest pfSense release.

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -13,14 +13,14 @@ RC_SCRIPT_URL="https://raw.githubusercontent.com/unofficial-unifi/unifi-pfsense/
 CURRENT_MONGODB_VERSION=mongodb42
 
 # If pkg-ng is not yet installed, bootstrap it:
-if ! /usr/sbin/pkg -N 2> /dev/null; then
+if ! /usr/sbin/pkg -N -- 2> /dev/null; then
   echo "FreeBSD pkgng not installed. Installing..."
   env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg bootstrap
   echo " done."
 fi
 
 # If installation failed, exit:
-if ! /usr/sbin/pkg -N 2> /dev/null; then
+if ! /usr/sbin/pkg -N -- 2> /dev/null; then
   echo "ERROR: pkgng installation failed. Exiting."
   exit 1
 fi


### PR DESCRIPTION
In pfSense 2.7.0-RELEASE (amd64), this script fails to execute due to the way the shell interprets `pkg -N 2> /dev/null` as `pkg -N 2` `> /dev/null`. By adding `--` we tell the shell that we're done adding parameters and values to pkg.