### PR TITLE
Update RC.d unifi.sh for firmware 7.5 and up Opnsense 23

### DIFF
--- a/rc.d/unifi.sh
+++ b/rc.d/unifi.sh
@@ -26,7 +26,7 @@ unifi_start()
 
     # The process will run until it is terminated and does not fork on its own.
     # So we start it in the background and stash the pid:
-    /usr/local/bin/java -jar /usr/local/UniFi/lib/ace.jar start &
+    /usr/local/bin/java --add-opens=java.base/java.time=ALL-UNNAMED -jar /usr/local/UniFi/lib/ace.jar start &
     echo $! > $pidfile
 
   fi


### PR DESCRIPTION
fix beta UniFi Network Application 7.5.187
Opnsense firmware
Is the following code changes safe to integrate in main branch? fixes issues with Opnsense and Unifi Network Controller Application 7.5 and up

[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-7-5-187/e6faa0fa-ebf2-497e-9e42-901a1840d206)

saw some posted this fix for the log errors in the main Unifi forums page...
by User "doestergaard"
[view post](https://community.ui.com/releases/UniFi-Network-Application-7-5-174/d05b091f-f00c-4ebb-8f42-b77e0adac78b?page=2)

```
/usr/local/etc/rc.d/unifi.sh
Try appending --add-opens=java.base/java.time=ALL-UNNAMED to your execstart:
ExecStart=/usr/bin/java --add-opens=java.base/java.time=ALL-UNNAMED -jar /opt/UniFi/lib/ace.jar 
```
using winscp I modified

```
    # So we start it in the background and stash the pid:
    /usr/local/bin/java -jar /usr/local/UniFi/lib/ace.jar start &
```
to

```
    # So we start it in the background and stash the pid:
    /usr/local/bin/java --add-opens=java.base/java.time=ALL-UNNAMED -jar /usr/local/UniFi/lib/ace.jar start &
```